### PR TITLE
add: 通知方法設定機能 #12

### DIFF
--- a/timer-rails/app/controllers/notifications_controller.rb
+++ b/timer-rails/app/controllers/notifications_controller.rb
@@ -1,0 +1,38 @@
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!, only: %i[create edit update]
+
+  def create
+    notification = current_user.build_notification(notification_params)
+
+    if notification.save
+      render json: { id: notification.id, email: current_user.email, message: '成功しました' }, status: :ok
+    else
+      render json: { message: '保存出来ませんでした', errors: notification.errors.messages }, status: :bad_request
+    end
+  end
+
+  def edit
+    notification = current_user.notification
+
+    if notification
+      render json: { id: notification.id, way: notification.way }, status: :ok
+    end
+  end
+
+  def update
+    notification = current_user.notification
+
+    if notification.update(notification_params)
+      render json: { id: notification.id, way: notification.way, message: '成功しました' }, status: :ok
+    else
+      render json: { message: '更新出来ませんでした', errors: notification.errors.messages }, status: :bad_request
+    end
+  end
+
+  private
+
+  def notification_params
+    params.permit(:way)
+  end
+
+end

--- a/timer-rails/app/models/notification.rb
+++ b/timer-rails/app/models/notification.rb
@@ -1,0 +1,3 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+end

--- a/timer-rails/app/models/user.rb
+++ b/timer-rails/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
+  has_one :notification, dependent: :destroy
+
   validates :name, presence: true
   validates :name, length: { maximum: 15 }
 end

--- a/timer-rails/config/routes.rb
+++ b/timer-rails/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth', controllers: {
-    registrations: 'auth/registrations'
-  }
+  constraints format: :json do
+    mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+      registrations: 'auth/registrations'
+    }
+
+  resource :notifications, only: %i[create edit update]
+  end
 end

--- a/timer-rails/db/migrate/20230512170300_create_notifications.rb
+++ b/timer-rails/db/migrate/20230512170300_create_notifications.rb
@@ -1,0 +1,10 @@
+class CreateNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notifications do |t|
+      t.boolean :way, default: false, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/timer-rails/db/schema.rb
+++ b/timer-rails/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_12_144334) do
+ActiveRecord::Schema.define(version: 2023_05_12_170300) do
+
+  create_table "notifications", force: :cascade do |t|
+    t.boolean "way", default: false, null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -31,4 +39,5 @@ ActiveRecord::Schema.define(version: 2023_05_12_144334) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "notifications", "users"
 end


### PR DESCRIPTION
### 概要
- notificationsテーブルを作成しました。
- 通知方法を選択する機能・現在の通知方法を取得する機能・通知方法を更新する機能を追加しました。(Postmanを使用して機能確認済み)

### 確認方法
1. テーブルを追加したので bundle exec rails db:migrate を実行してください。
2. 通知方法設定機能を、Postmanを使って問題なく動くか確認して下さい。
3. 通知方法設定機能のリクエストが、ユーザがログインしている場合のみ成功することを確認して下さい。

### コメント
editアクションとupdateアクション共通の`notification = current_user.notification`コードをメソッド定義して`before_action`で呼び出そうとしましたが、エラーになった為、断念しました。
恐らく、`before_action :authenticate_user!, only: %i[create edit update]`との複数呼び出しが原因だと考えます。