### PR TITLE
add: 1時間座り続けたことで縮んだ寿命の合計時間を確認できる機能 #11

### DIFF
--- a/timer-rails/app/controllers/total_shortened_lifespans_controller.rb
+++ b/timer-rails/app/controllers/total_shortened_lifespans_controller.rb
@@ -1,0 +1,37 @@
+class TotalShortenedLifespansController < ApplicationController
+  before_action :authenticate_user!, only: %i[create show update]
+
+  def create
+    total_time = current_user.build_total_shortened_lifespan
+
+    if total_time.save
+      render json: { id: total_time.id, email: current_user.email, message: '成功しました' }, status: :ok
+    else
+      render json: { message: '保存出来ませんでした', errors: total_time.errors.messages }, status: :bad_request
+    end
+  end
+
+  def show
+    total_time = current_user.total_shortened_lifespan
+
+    if total_time
+      render json: { id: total_time.id, time: total_time.time }, status: :ok
+    end
+  end
+
+  def update
+    total_time = current_user.total_shortened_lifespan
+    if total_time.update(time_params)
+      render json: { id: total_time.id, time: total_time.time, message: '成功しました' }, status: :ok
+    else
+      render json: { message: '更新出来ませんでした', errors: total_time.errors.messages }, status: :bad_request
+    end
+  end
+
+  private
+
+  def time_params
+    params.permit(:time)
+  end
+
+end

--- a/timer-rails/app/models/total_shortened_lifespan.rb
+++ b/timer-rails/app/models/total_shortened_lifespan.rb
@@ -1,0 +1,5 @@
+class TotalShortenedLifespan < ApplicationRecord
+  belongs_to :user
+
+  validates :time, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+end

--- a/timer-rails/app/models/user.rb
+++ b/timer-rails/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   has_one :notification, dependent: :destroy
+  has_one :total_shortened_lifespan, dependent: :destroy
 
   validates :name, presence: true
   validates :name, length: { maximum: 15 }

--- a/timer-rails/config/routes.rb
+++ b/timer-rails/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       registrations: 'auth/registrations'
     }
 
-  resource :notifications, only: %i[create edit update]
+    resource :notifications, only: %i[create edit update]
+    resource :total_shortened_lifespans, only: %i[create show update]
   end
 end

--- a/timer-rails/db/migrate/20230516063212_create_total_shortened_lifespans.rb
+++ b/timer-rails/db/migrate/20230516063212_create_total_shortened_lifespans.rb
@@ -1,0 +1,10 @@
+class CreateTotalShortenedLifespans < ActiveRecord::Migration[6.0]
+  def change
+    create_table :total_shortened_lifespans do |t|
+      t.integer :time, default: 0, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/timer-rails/db/schema.rb
+++ b/timer-rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_12_170300) do
+ActiveRecord::Schema.define(version: 2023_05_16_063212) do
 
   create_table "notifications", force: :cascade do |t|
     t.boolean "way", default: false, null: false
@@ -18,6 +18,14 @@ ActiveRecord::Schema.define(version: 2023_05_12_170300) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
+  create_table "total_shortened_lifespans", force: :cascade do |t|
+    t.integer "time", default: 0, null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_total_shortened_lifespans_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -40,4 +48,5 @@ ActiveRecord::Schema.define(version: 2023_05_12_170300) do
   end
 
   add_foreign_key "notifications", "users"
+  add_foreign_key "total_shortened_lifespans", "users"
 end


### PR DESCRIPTION
### 概要
- total_shortened_lifespansテーブルを作成しました。
- 1時間座り続けたことで縮んだ寿命の合計時間を記録する機能・1時間座り続けたことで縮んだ寿命の合計時間を更新する機能・1時間座り続けたことで縮んだ寿命の合計時間を取得する機能を追加しました。(Postmanを使用して機能確認済み)

### 確認方法
1. テーブルを追加したので bundle exec rails db:migrate を実行してください。
2. 1時間座り続けたことで縮んだ寿命の合計時間を確認できる機能を、Postmanを使って問題なく動くか確認して下さい。
3. 1時間座り続けたことで縮んだ寿命の合計時間を確認できる機能のリクエストが、ユーザがログインしている場合のみ成功することを確認して下さい。