### PR TITLE
fix: 現在の通知方法を取得する機能 #35

### DIFF
--- a/timer-rails/app/controllers/notifications_controller.rb
+++ b/timer-rails/app/controllers/notifications_controller.rb
@@ -1,5 +1,5 @@
 class NotificationsController < ApplicationController
-  before_action :authenticate_user!, only: %i[create edit update]
+  before_action :authenticate_user!, only: %i[create show update]
 
   def create
     notification = current_user.build_notification(notification_params)
@@ -11,7 +11,7 @@ class NotificationsController < ApplicationController
     end
   end
 
-  def edit
+  def show
     notification = current_user.notification
 
     if notification

--- a/timer-rails/config/routes.rb
+++ b/timer-rails/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       registrations: 'auth/registrations'
     }
 
-    resource :notifications, only: %i[create edit update]
+    resource :notifications, only: %i[create show update]
     resource :total_shortened_lifespans, only: %i[create show update]
   end
 end


### PR DESCRIPTION
### 概要
- notificationsコントローラーのeditアクションをshowアクションに修正しました。(Postmanを使用して機能の動作確認済み)

### 確認方法
1. 現在の通知方法を取得する機能を、Postmanを使って問題なく動くか確認して下さい。
2. 現在の通知方法を取得する機能のリクエストが、ユーザがログインしている場合のみ成功することを確認して下さい。

### コメント
editアクションは通知方法の編集画面を表示するために使用されるべきで、また通知方法は一つのリソースであり、その詳細を取得するためにshowアクションを使用するのが適切だと考え、修正しました。