### PR TITLE
add: 1日のタイマー記録機能 #13

### DIFF
--- a/timer-rails/app/controllers/one_day_times_controller.rb
+++ b/timer-rails/app/controllers/one_day_times_controller.rb
@@ -1,0 +1,37 @@
+class OneDayTimesController < ApplicationController
+  before_action :authenticate_user!, only: %i[create index]
+
+  def create
+    today_time = current_user.one_day_times.build(today_time_params)
+
+    if today_time.save
+      render json: { id: today_time.id, email: current_user.email, message: '成功しました' }, status: :ok
+    else
+      render json: { message: '保存出来ませんでした', errors: today_time.errors.messages }, status: :bad_request
+    end
+  end
+
+  def index
+    now = Time.current
+    one_week_times = current_user.one_day_times.where(created_at: now.all_week)
+
+    one_week_times_array = one_week_times.map do |time|
+      {
+        id: time.id,
+        count_up: time.count_up,
+        exercise: time.exercise,
+        shortened_lifespan: time.shortened_lifespan,
+        created_at: time.created_at
+      }
+    end
+
+    render json: one_week_times_array, status: :ok
+  end
+
+  private
+
+  def today_time_params
+    params.permit(:count_up, :exercise, :shortened_lifespan)
+  end
+
+end

--- a/timer-rails/app/models/one_day_time.rb
+++ b/timer-rails/app/models/one_day_time.rb
@@ -1,0 +1,5 @@
+class OneDayTime < ApplicationRecord
+  belongs_to :user
+
+  validates :count_up, :exercise, :shortened_lifespan, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+end

--- a/timer-rails/app/models/user.rb
+++ b/timer-rails/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ActiveRecord::Base
 
   has_one :notification, dependent: :destroy
   has_one :total_shortened_lifespan, dependent: :destroy
+  has_many :one_day_times, dependent: :destroy
 
   validates :name, presence: true
   validates :name, length: { maximum: 15 }

--- a/timer-rails/config/routes.rb
+++ b/timer-rails/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
 
     resource :notifications, only: %i[create show update]
     resource :total_shortened_lifespans, only: %i[create show update]
+    resources :one_day_times, only: %i[create index]
   end
 end

--- a/timer-rails/db/migrate/20230516140227_create_one_day_times.rb
+++ b/timer-rails/db/migrate/20230516140227_create_one_day_times.rb
@@ -1,0 +1,12 @@
+class CreateOneDayTimes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :one_day_times do |t|
+      t.integer :count_up, default: 0, null: false
+      t.integer :exercise, default: 0, null: false
+      t.integer :shortened_lifespan, default: 0, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/timer-rails/db/schema.rb
+++ b/timer-rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_16_063212) do
+ActiveRecord::Schema.define(version: 2023_05_16_140227) do
 
   create_table "notifications", force: :cascade do |t|
     t.boolean "way", default: false, null: false
@@ -18,6 +18,16 @@ ActiveRecord::Schema.define(version: 2023_05_16_063212) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
+  create_table "one_day_times", force: :cascade do |t|
+    t.integer "count_up", default: 0, null: false
+    t.integer "exercise", default: 0, null: false
+    t.integer "shortened_lifespan", default: 0, null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_one_day_times_on_user_id"
   end
 
   create_table "total_shortened_lifespans", force: :cascade do |t|
@@ -48,5 +58,6 @@ ActiveRecord::Schema.define(version: 2023_05_16_063212) do
   end
 
   add_foreign_key "notifications", "users"
+  add_foreign_key "one_day_times", "users"
   add_foreign_key "total_shortened_lifespans", "users"
 end

--- a/timer-rails/db/seeds.rb
+++ b/timer-rails/db/seeds.rb
@@ -1,7 +1,10 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# 4日分のデータを作成
+4.times do |n|
+  date = n.days.ago # n.days.agoはRailsのActive Supportライブラリによって提供される便利なメソッドであり、指定した日数の時間差を適用した現在の日時を返します。例えば、1.day.agoは1日前の日時を返します。
+
+  # データの作成処理
+    OneDayTime.create!(count_up: 30*n, exercise: n, shortened_lifespan: 22*n, user_id: User.first.id , created_at: date, updated_at: date)
+    puts "#{n}日前のメッセージを作成しました"
+end
+
+puts "4日分の作成が完了しました"


### PR DESCRIPTION
### 概要
- one_day_timesテーブルを作成しました。
- 1日(タイマーstartからendまで)のタイマー記録機能・1日ごとのタイマー記録の一覧取得する機能(ユーザーごとの)を追加しました。(Postmanを使用して機能確認済み)
- テスト用にSeedで初期データを作成しました。

### 確認方法
1. テーブルを追加したので bundle exec rails db:migrate を実行してください。
2. Seedで初期データを作成したのでbundle exec rails db:seedを実行してレコードを作成してください。
3. 1日のタイマー記録機能を、Postmanを使って問題なく動くか確認して下さい。
4. 1日のタイマー記録機能のリクエストが、ユーザがログインしている場合のみ成功することを確認して下さい。