### PR TITLE
独自ドメイン取得によるフッターとRailsAPIでのCORS設定の修正 #53

### DIFF
--- a/timer-rails/config/initializers/cors.rb
+++ b/timer-rails/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
    allow do
-     origins '*'
+     origins 'localhost:8080','https://www.shinigami-timer.com'
 
      resource '*',
        headers: :any,

--- a/timer-vuejs/src/components/FooterLink.vue
+++ b/timer-vuejs/src/components/FooterLink.vue
@@ -2,7 +2,7 @@
   <div class="footer-line"></div>
   <footer class="footer">
   <div class="md-flex md-justify-between">
-      <p><span>the Grim Reaper Timer</span><br>© 2023 JAJAAAN Inc. All Rights Reserved.</p>
+      <p><span>the Grim Reaper Timer</span><br>shinigami-timer.com 2023</p>
     <ul class="footer__navi flex">
       <li>利用規約</li>
       <li>プライバシーポリシー</li>


### PR DESCRIPTION
### 概要
独自ドメインを取得したので、以下を修正しました。
- FooterLink.vue (FooterPage.vueに遷移するリンク表示コンポーネント)にドメイン名を表記しました。
- Rails APIで、特定のオリジンのみ許可するようにCORS設定を変更しました。

### 確認観点
`shinigami-timer.com`でアクセスして下さい。
- [x] FooterLink.vueにアプリ名の下にドメイン名が表記されている。
- [x] コンソールからRails API通信が正常に動作していることを確認して下さい。